### PR TITLE
 fix: configure script should use /usr/bin/env

### DIFF
--- a/Overlay/configure
+++ b/Overlay/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Configure script for Babble Gaze Eye Tracking
 # Supports macOS and Linux


### PR DESCRIPTION
This better supports linux distros that don't comply with FHS, such as NixOS