### PR TITLE
chore: Add nixos related stuff to gitignore, also C stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 /Inference/__pycache__
 /Inference/dev
 /Inference/utils/__pycache__
+
+**/*.o
+Makefile
+
+.envrc
+.direnv/


### PR DESCRIPTION
Motivation: NixOS users tend to use .envrc files (for https://direnv.net/) and also the associated .direnv directory. These should not be committed to the repo and therefore there's no reason the project shouldnt gitignore them.

I also noticed that .o files were not excluded, as well as the makefile that ./configure generates.